### PR TITLE
Basis of resources, diffing, metadata

### DIFF
--- a/beam_interactive2/_util.py
+++ b/beam_interactive2/_util.py
@@ -1,0 +1,120 @@
+metadata_prop_name = "meta"
+etag_prop_name = "etag"
+
+
+class DiffSettable(object):
+    def __init__(self, data, immutable=[etag_prop_name]):
+        """Data should be a dict of keys to *something*, passed through
+        _get_data and returned from _set_data. Immutable is a list of properties
+        we should not allow the caller to change.
+        """
+        self.__data = {}
+        self.__changed = []
+        self.__immutable = immutable
+        self._bypass_setter = False
+        self.apply_update(data)
+
+    def _get_data(self, key, raw_value):
+        """Called when looking up a key, passed the value inside of the `data`.
+        It may transform and return the value as necessary.
+        """
+        return raw_value
+
+    def _set_data(self, key, raw_value, previous_value):
+        """Called when updating a key, passed the value being updated. It may
+        transform and return the value as necessary before it's stored."""
+        return raw_value
+
+    def _create_changes(self, mapping):
+        """Called when creating a change list. Mapping a dict of change keys
+        to the raw objects. The dict may be mutated and returned.
+        """
+        return mapping
+
+    def has_changed(self):
+        """Returns whether the resource has had changes made to it."""
+        return len(self.__changed) > 0
+
+    def apply_update(self, change):
+        """Updates the properties stored on the resource."""
+        for key, value in change.items():
+            if key not in self.__changed:
+                self.__data[key] = value
+
+    def capture_changes(self):
+        """Returns an object of changed properties that can be used to patch
+        the resource.
+        """
+        changed = {}
+        for key in self.__changed:
+            changed[key] = self.__data[key]
+        self.__changed = []
+
+        return self._create_changes(changed)
+
+    def __setattr__(self, key, value):
+        if (len(key) > 0 and key[0] == '_') or self._bypass_setter:
+            self.__dict__[key] = value
+            return
+
+        if key in self.__immutable:
+            raise AttributeError('Refusing to set immutable attribute {}'
+                                 .format(key))
+
+        previous_value = None
+        if key in self.__data:
+            previous_value = self.__data[key]
+
+        if previous_value != value:
+            self.__data[key] = self._set_data(key, value, previous_value)
+            self.__changed.append(key)
+
+    def __getattr__(self, key):
+        if key not in self.__data:
+            raise AttributeError()
+
+        return self._get_data(key, self.__data[key])
+
+
+class Metadata(DiffSettable):
+    def _get_data(self, key, raw_value):
+        return raw_value['value']
+
+    def _set_data(self, key, raw_value, previous_value):
+        if previous_value is not None:
+            return {'value': raw_value, 'etag': previous_value['etag']}
+
+        return {'value': raw_value}
+
+
+class Resource(DiffSettable):
+    """Resource represents some taggable, metadata-attachable construct in
+    Interactive. Scenes, groups, and participants are resources.
+    """
+
+    def __init__(self, **kwargs):
+        self._bypass_setter = True
+        self.meta = Metadata({})
+        self._bypass_setter = False
+
+        super(Resource, self).__init__(kwargs)
+
+    def has_changed(self):
+        return self.meta.has_changed() or super(Resource, self).has_changed()
+
+    def apply_update(self, change):
+        if metadata_prop_name in change:
+            self.meta.apply_update(change[metadata_prop_name])
+            del change[metadata_prop_name]
+
+        super(Resource, self).apply_update(change)
+
+    def _create_changes(self, mapping):
+        """Called when creating a change list. Mapping a dict of change keys
+        to the raw objects. The dict may be mutated and returned.
+        """
+        mapping[etag_prop_name] = getattr(self, etag_prop_name)
+        if self.meta.has_changed():
+            mapping[metadata_prop_name] = self.meta.capture_changes()
+
+        return mapping

--- a/beam_interactive2/connection.py
+++ b/beam_interactive2/connection.py
@@ -171,7 +171,7 @@ class Connection:
         """
 
         item = await self._recv_queue.get()
-        if isinstance(item, Exception):
+        if isinstance(item, websockets.ConnectionClosed):
             self._recv_queue.put_nowait(item)
             raise item
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
-# beam-interactive-python2 [![Build Status](https://travis-ci.org/WatchBeam/beam-interactive-python2.svg)](https://travis-ci.org/WatchBeam/beam-interactive-python2)
+# interactive-python [![Build Status](https://travis-ci.org/WatchBeam/interactive-python.svg)](https://travis-ci.org/WatchBeam/interactive-python)
 
 This is a base implementation of a Beam Interactive 2 game client. Documentation for the protocol and tutorials can be found on our [developer site](https://dev.beam.pro)

--- a/tests/resource_test.py
+++ b/tests/resource_test.py
@@ -1,0 +1,51 @@
+import unittest
+from beam_interactive2._util import Resource
+
+
+def get_fixture():
+    return Resource(groupID='red_team', etag='1234',
+                    meta={'enabled': {'etag': '5678', 'value': True}})
+
+
+class TestGzipEncoding(unittest.TestCase):
+
+    def test_accesses_data(self):
+        resource = get_fixture()
+        self.assertEqual("red_team", resource.groupID)
+        self.assertEqual(True, resource.meta.enabled)
+        with self.assertRaises(AttributeError):
+            resource.meta.wut
+        with self.assertRaises(AttributeError):
+            resource.wut
+
+    def tests_diffs_resource(self):
+        resource = get_fixture()
+        resource.disabled = True  # adding a new property
+        resource.groupID = 'blue_team'  # modifying an existing property
+        self.assertTrue(resource.has_changed())
+        self.assertEqual(
+            {'etag':'1234', 'groupID': 'blue_team', 'disabled': True},
+            resource.capture_changes()
+        )
+        self.assertFalse(resource.has_changed())
+
+        resource.groupID = 'blue_team'  # setting but not changing the prop
+        self.assertFalse(resource.has_changed())
+        self.assertEqual({'etag': '1234'}, resource.capture_changes())
+
+    def test_fails_to_set_immutable_properties(self):
+        with self.assertRaises(AttributeError):
+            get_fixture().etag = 'wut'
+
+    def test_includes_changes_to_metadata(self):
+        resource = get_fixture()
+        resource.meta.enabled = False
+        self.assertTrue(resource.has_changed())
+        self.assertEqual(
+            {
+                'etag': '1234',
+                'meta': {'enabled': {'etag': '5678', 'value': False}}
+             },
+            resource.capture_changes()
+        )
+        self.assertFalse(resource.has_changed())


### PR DESCRIPTION
This PR adds the foundation of resources (groups, participants, controls, scenes). It creates a "Resource" class, which handles the metadata and etagging as well as property lookups. All other resources will extend from this base class.