### PR TITLE
Oauth and Scene control updates

### DIFF
--- a/interactive_python/oauth.py
+++ b/interactive_python/oauth.py
@@ -75,14 +75,20 @@ class OAuthShortCode:
         address = self._grant.url('/oauth/token')
         payload = {
             'client_id': self._grant.client_id,
+            'client_secret': self._grant.client_secret,
             'grant_type': 'authorization_code',
             'code': body['code'],
+            'redirect_uri': ''
+        }
+        headers = {
+            'content-type': 'application/json',
+            'client-id': self._grant.client_id
         }
 
-        async with self._client.post(address, json=payload) as res:
+        async with self._client.post(address, json=payload, headers=headers) as res:
             if res.status != 200:
-                raise UnknownShortCodeError('Expected a 2xx status code, but'
-                                            'got {}'.format(res.status))
+                raise UnknownShortCodeError('Expected a 2xx status code, but '
+                                            'got {0} : reason {1}'.format(res.status, await res.text()))
 
             return OAuthTokens(await res.json())
 
@@ -162,7 +168,7 @@ class OAuthClient:
 
         async with self._client.post(address, json=payload) as res:
             if res.status >= 300:
-                raise UnknownShortCodeError('Expected a 2xx status code, but'
-                                            'got {}'.format(res.status))
+                raise UnknownShortCodeError('Expected a 2xx status code, but '
+                                            'got {0} : reason {1}'.format(res.status, await res.text()))
 
             return OAuthShortCode(self._grant, self._client, await res.json())

--- a/interactive_python/scene.py
+++ b/interactive_python/scene.py
@@ -44,16 +44,18 @@ class Scene(Resource):
             {'scenes': [self._capture_changes()], 'priority': priority}
         )
 
+    def attach_controls(self, *controls):
+        for control in controls:
+            self.controls[control.id] = control
+            control._attach_scene(self)
+
     async def create_controls(self, *controls):
         """
         Can be called with one or more Controls to add them to to the scene.
         :param controls: list of controls to create
         :type controls: List[Control]
         """
-        for control in controls:
-            self.controls[control.id] = control
-            control._attach_scene(self)
-
+        self.attach_controls(controls)
         return await self._connection.call('createControls', {
             'sceneID': self.id,
             'controls': controls,

--- a/interactive_python/scene.py
+++ b/interactive_python/scene.py
@@ -45,13 +45,18 @@ class Scene(Resource):
         )
 
     def attach_controls(self, *controls):
+        """
+        Can be called with one or more Controls to add them to to the scene.
+        :param controls: list of controls to create
+        :type controls: List[Control]
+        """
         for control in controls:
             self.controls[control.id] = control
             control._attach_scene(self)
 
     async def create_controls(self, *controls):
         """
-        Can be called with one or more Controls to add them to to the scene.
+        Define and create one or more controls, and add them to the scene.
         :param controls: list of controls to create
         :type controls: List[Control]
         """
@@ -117,6 +122,17 @@ class Control(Resource):
         btn.on('mousedown', lambda call: print(call))
 
         await state.scene('default').create_controls(btn)
+
+    When using controls defined in the interactive studio editor, you only need to
+    define the control_id, and the events then attach them to the scene.
+
+        js = Joystick(control_id='joystick_1')
+        btn = Button(control_id='click_me')
+
+        js.on('move', lambda call: print(call.data['input'].x, call.data['input'].y))
+        btn.on('mousedown', lambda call: print(call))
+
+        state.scene('default').attach_controls(js, btn)
 
     """
 


### PR DESCRIPTION
Here's a few changes I completed to get the python library to work for me. Found the oauth was missing the client_secret when requesting the /oauth/token. For people using interactive studio, I split the control attachment and control creation into two separate functions. I also updated the instructions to include joysticks.